### PR TITLE
Adjustments to support the switch to the latest USM release (2.1.11) at runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
     <scm.url>scm:git:https://github.com/UnionVMS/UVMS-USM4UVMSLibrary.git</scm.url>
 
     <javaee.version>8.0</javaee.version>
-    <jjwt.version>0.4</jjwt.version>
     <ehcache.version>2.10.4</ehcache.version>
     <apache.commons.version>3.7</apache.commons.version>
     <jackson.version>2.6.7</jackson.version>
@@ -232,17 +231,6 @@
       <version>${uvms.user.module.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt</artifactId>
-      <version>${jjwt.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <dependency>
       <groupId>javax</groupId>
       <artifactId>javaee-api</artifactId>

--- a/src/main/java/eu/europa/ec/fisheries/uvms/rest/security/AuthenticationFilter.java
+++ b/src/main/java/eu/europa/ec/fisheries/uvms/rest/security/AuthenticationFilter.java
@@ -1,16 +1,17 @@
 package eu.europa.ec.fisheries.uvms.rest.security;
 
 import eu.europa.ec.fisheries.uvms.constants.AuthConstants;
-import eu.europa.ec.mare.usm.jwt.DefaultJwtTokenHandler;
 import java.io.IOException;
+import javax.ejb.EJB;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import eu.europa.ec.mare.usm.jwt.JwtTokenHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +27,8 @@ public class AuthenticationFilter implements Filter {
     private static final String AUTHENTICATE = "/authenticate";
     private static final String PING = "/ping";
 
-    private DefaultJwtTokenHandler tokenHandler;
+    @EJB
+    private JwtTokenHandler tokenHandler;
 
     /**
      * Creates a new instance
@@ -101,15 +103,4 @@ public class AuthenticationFilter implements Filter {
             }
         }
     }
-
-    @Override
-    public void init(FilterConfig fc) {
-        tokenHandler = new DefaultJwtTokenHandler();
-    }
-
-    @Override
-    public void destroy() {
-        // NOP
-    }
-
 }


### PR DESCRIPTION
Switching to USM 2.1.11 required further work:

- The `DefaultJwtTokenHandler` has become an EJB. We are now injecting it, instead of creating it in the `AuthenticationFilter`; creating it with `new` skips its `@PostConstruct` initialization logic and breaks the application
- The dependencies to io.jsonwebtoken have been updated in USM.  We no longer depend on it explicitly, rather transitively through `eu.europa.ec.mare.usm:jwt-handler-impl`