### PR TITLE
Corrections in UserRoleRequestWrapper

### DIFF
--- a/src/main/java/eu/europa/ec/fisheries/uvms/constants/AuthConstants.java
+++ b/src/main/java/eu/europa/ec/fisheries/uvms/constants/AuthConstants.java
@@ -24,10 +24,6 @@ public interface AuthConstants {
 
     String JWTCALLBACK = "jwtcallback";
 
-    String HTTP_SERVLET_CONTEXT_ATTR_FEATURES = "servletContextUserFeatures";
-
-    String HTTP_SESSION_ATTR_ROLES_NAME = HTTP_SERVLET_CONTEXT_ATTR_FEATURES;
-
     String CACHE_NAME_USER_SESSION = "userSessionCache";
     String CACHE_NAME_APP_MODULE = "appModuleCache";
 }

--- a/src/main/java/eu/europa/ec/fisheries/uvms/rest/security/UserRoleRequestWrapper.java
+++ b/src/main/java/eu/europa/ec/fisheries/uvms/rest/security/UserRoleRequestWrapper.java
@@ -29,7 +29,6 @@ public class UserRoleRequestWrapper extends HttpServletRequestWrapper {
 
     private String user;
     private Set<String> roles = null;
-    private HttpServletRequest realRequest;
 
     /**
      * a constructor which allows us to insert the available roles into the current request
@@ -42,8 +41,6 @@ public class UserRoleRequestWrapper extends HttpServletRequestWrapper {
         super(request);
         this.user = user;
         this.setRoles(roles);
-        request.getServletContext().setAttribute(AuthConstants.HTTP_SERVLET_CONTEXT_ATTR_FEATURES, roles); //this is needed, because RESTEasy creates proxy objects and in a rest method, I cannot cast to this wrapper and call wrapper.getRoles();
-        this.realRequest = request;
     }
 
     /**
@@ -71,7 +68,7 @@ public class UserRoleRequestWrapper extends HttpServletRequestWrapper {
     @Override
     public boolean isUserInRole(String role) {
         if (getRoles() == null) {
-            return this.realRequest.isUserInRole(role);
+            return ((HttpServletRequest) getRequest()).isUserInRole(role);
         }
         return getRoles().contains(role);
     }
@@ -79,7 +76,7 @@ public class UserRoleRequestWrapper extends HttpServletRequestWrapper {
     @Override
     public Principal getUserPrincipal() {
         if (this.user == null) {
-            return realRequest.getUserPrincipal();
+            return ((HttpServletRequest) getRequest()).getUserPrincipal();
         }
         // make an anonymous implementation to just return our user
         return new Principal() {
@@ -97,5 +94,4 @@ public class UserRoleRequestWrapper extends HttpServletRequestWrapper {
     public void setRoles(Set<String> roles) {
         this.roles = roles;
     }
-
 }

--- a/src/test/java/eu/europa/ec/fisheries/uvms/rest/security/UserRoleRequestWrapperTest.java
+++ b/src/test/java/eu/europa/ec/fisheries/uvms/rest/security/UserRoleRequestWrapperTest.java
@@ -1,0 +1,44 @@
+package eu.europa.ec.fisheries.uvms.rest.security;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+/**
+ * Tests for the {@link UserRoleRequestWrapper}.
+ */
+public class UserRoleRequestWrapperTest {
+
+	private static final String USER_NAME = "snoopy";
+	private static final String ROLE_NAME = "role-name";
+
+	@Test
+	public void testIsUserInRoleDelegatesWhenRolesAreNotSet() {
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.isUserInRole(ROLE_NAME)).thenReturn(true);
+		UserRoleRequestWrapper sut = new UserRoleRequestWrapper(mockRequest, USER_NAME);
+		boolean result = sut.isUserInRole(ROLE_NAME);
+		assertTrue(result);
+		verify(mockRequest).isUserInRole(ROLE_NAME);
+		verifyNoMoreInteractions(mockRequest);
+	}
+
+	@Test
+	public void testIsUserInRoleWhenRolesAreSet() {
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		UserRoleRequestWrapper sut = new UserRoleRequestWrapper(USER_NAME, Collections.singleton(ROLE_NAME), mockRequest);
+		boolean result = sut.isUserInRole(ROLE_NAME);
+		assertTrue(result);
+		verify(mockRequest, never()).isUserInRole(ROLE_NAME);
+		verifyNoMoreInteractions(mockRequest);
+	}
+}


### PR DESCRIPTION
- It placed the roles of the current user in the servlet context. Thankfully nothing was reading them from there. This is a dangerous practice because if more than one requests are processed concurrently, the roles will be mixed up. Removed.
- The standard `HttpServletRequestWrapper` already has facilities to store and retrieve the wrapped request. Removed the field `realRequest` from the `UserRoleRequestWrapper`.